### PR TITLE
feat: 배포용 HTTPS 요청 허용 태그 추가

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[[redirects]]
+from = "/*"
+to = "http://Sinderproject-env.eba-p3ciumxi.us-east-1.elasticbeanstalk.com/:splat"

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,12 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
+    <% if (process.env.NODE_ENV === 'production') { %>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="upgrade-insecure-requests"
+    />
+    <% } %>
     <meta name="theme-color" content="#000000" />
     <link rel="stylesheet" href="style.css" />
     <title>Chats Screen</title>


### PR DESCRIPTION
## 설명

Netlify 는 HTTPS 이고 백엔드는 HTTP 이기 때문에 요청을 혀용하는 태그를 넣어줬습니다.

## 변경 또는 추가한 로직
